### PR TITLE
Add Time preference cost

### DIFF
--- a/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
+++ b/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
@@ -18,7 +18,7 @@ class Scheduler_2
         end
     end
     
-    def self.exponential_cost_function(current_time, prior_of_day, later_of_day, start_of_day, end_of_day)
+    def self.exponential_cost_function(current_time, start_of_day, end_of_day)
         
         def self.sigmoid_cost_fuc(max_cost, alpha, beta, x)
             return max_cost / (1+Math::exp(-1*(alpha*max_cost*x) + (beta*max_cost)))
@@ -82,7 +82,7 @@ class Scheduler_2
                     end
                 end
                 
-                @time_preference_cost = self.exponential_cost_function(current_time, prior_of_day, later_of_day, start_of_day, end_of_day)
+                @time_preference_cost = self.exponential_cost_function(current_time, start_of_day, end_of_day)
                 @time_preference_mod = Conflict.new
                 @time_preference_mod.cost = @time_preference_cost
                 @time_preference_mod.save

--- a/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
+++ b/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
@@ -25,14 +25,15 @@ class Scheduler_2
         end
         max_cost = 100
         prior_alpha = -0.015
-        prior_beta = 0.05
+        prior_beta = 0.025
         later_alpha = 0.01
         later_beta = 0.07
         # https://www.desmos.com/calculator
         
         if current_time < start_of_day
-            x = (current_time.to_f - start_of_day.to_f)/900
-            cost = self.sigmoid_cost_fuc(max_cost, prior_alpha, prior_beta, x)
+            cost = max_cost - 1
+            # x = (current_time.to_f - start_of_day.to_f)/900
+            # cost = self.sigmoid_cost_fuc(max_cost, prior_alpha, prior_beta, x)
         elsif current_time > end_of_day
             x = (current_time.to_f - end_of_day.to_f)/900
             cost = self.sigmoid_cost_fuc(max_cost, later_alpha, later_beta, x)


### PR DESCRIPTION
Add Time Preferences - Algorithm

This is the time preference algorithm that generates time costs.
I used two sigmoid functions so that both of the edges of timeslots have higher costs and the main (8am-5pm) timeslots have almost 0 costs.