### PR TITLE
Fix chosen data type error and other edge cases on it

### DIFF
--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -46,13 +46,13 @@ class UsersController < ApplicationController
   
   def import_from_excel
     begin
-      if !params[:file]
+      file = params[:file]
+      if !file
         record_message = "Import Failed : File is not chosen"
       elsif params[:name].empty?
         record_message = "Import Failed : Cohort name is not assigned"
       else
         # Retreive the extension of the file
-        file = params[:file]
         file_ext = File.extname(file.original_filename)
         # raise "Unknown file type: #{file.original_filename}" unless [".xls", ".xlsx"].include?(file_ext)
         if [".xls", ".xlsx"].include?(file_ext)
@@ -74,7 +74,7 @@ class UsersController < ApplicationController
             @cohort.users.push(@user)
           end
           record_message = "Records Imported"
-        elsif 
+        else
           record_message = "Import Failed :" + "Unknown file type: #{file.original_filename}"
         end
       end

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -45,8 +45,8 @@ class UsersController < ApplicationController
   end
   
   def import_from_excel
-    file = params[:file]
     begin
+      file = params[:file]
       if !file
         record_message = "Import Failed : File is not chosen"
       elsif params[:name].empty?

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -45,29 +45,41 @@ class UsersController < ApplicationController
   end
   
   def import_from_excel
-     file = params[:file]
-     @cohort = Cohort.new
-     @cohort.update_attributes(:name => params[:name])
+    file = nil
+    file = params[:file]
     begin
-      # Retreive the extension of the file
-      file_ext = File.extname(file.original_filename)
-      raise "Unknown file type: #{file.original_filename}" unless [".xls", ".xlsx"].include?(file_ext)
-      spreadsheet = (file_ext == ".xls") ? Roo::Excel.new(file.path) : Roo::Excelx.new(file.path)
-      header = spreadsheet.row(1)
-      ## We are iterating from row 2 because we have left row one for header
-      (2..spreadsheet.last_row).each do |i|
-        @user = User.new
-        puts spreadsheet.row(i)[0]
-        @user.firstname = spreadsheet.row(i)[0]
-        @user.lastname = spreadsheet.row(i)[1]
-        @user.uin = spreadsheet.row(i)[2]
-        @user.email = spreadsheet.row(i)[3]
-        @user.role = 'student'
-        @user.password = "Temp"
-        @user.save
-        @cohort.users.push(@user)
-    end
-    flash[:notice] = "Records Imported"
+      if !params[:file]
+        record_message = "Import Failed : File is not chosen"
+      elsif params[:name].empty?
+        record_message = "Import Failed : Cohort name is not assigned"
+      else
+        # Retreive the extension of the file
+        file_ext = File.extname(file.original_filename)
+        # raise "Unknown file type: #{file.original_filename}" unless [".xls", ".xlsx"].include?(file_ext)
+        if [".xls", ".xlsx"].include?(file_ext)
+          @cohort = Cohort.new
+          @cohort.update_attributes(:name => params[:name])
+          spreadsheet = (file_ext == ".xls") ? Roo::Excel.new(file.path) : Roo::Excelx.new(file.path)
+          header = spreadsheet.row(1)
+          ## We are iterating from row 2 because we have left row one for header
+          (2..spreadsheet.last_row).each do |i|
+            @user = User.new
+            puts spreadsheet.row(i)[0]
+            @user.firstname = spreadsheet.row(i)[0]
+            @user.lastname = spreadsheet.row(i)[1]
+            @user.uin = spreadsheet.row(i)[2]
+            @user.email = spreadsheet.row(i)[3]
+            @user.role = 'student'
+            @user.password = "Temp"
+            @user.save
+            @cohort.users.push(@user)
+          end
+          record_message = "Records Imported"
+        elsif 
+          record_message = "Import Failed :" + "Unknown file type: #{file.original_filename}"
+        end
+      end
+    flash[:notice] = record_message
     redirect_to manage_cohorts_path
     end
   end

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -46,13 +46,13 @@ class UsersController < ApplicationController
   
   def import_from_excel
     begin
-      file = params[:file]
-      if !file
+      if !params[:file]
         record_message = "Import Failed : File is not chosen"
       elsif params[:name].empty?
         record_message = "Import Failed : Cohort name is not assigned"
       else
         # Retreive the extension of the file
+        file = params[:file]
         file_ext = File.extname(file.original_filename)
         # raise "Unknown file type: #{file.original_filename}" unless [".xls", ".xlsx"].include?(file_ext)
         if [".xls", ".xlsx"].include?(file_ext)

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -45,10 +45,9 @@ class UsersController < ApplicationController
   end
   
   def import_from_excel
-    file = nil
     file = params[:file]
     begin
-      if !params[:file]
+      if !file
         record_message = "Import Failed : File is not chosen"
       elsif params[:name].empty?
         record_message = "Import Failed : Cohort name is not assigned"


### PR DESCRIPTION
1. Set only excel file extension can be uploaded.
2. If there is no file chosen (uploaded) or cohort name is not assigned Import failure message will be shown instead of the message "Records Imported" on the manage cohorts page.