### PR TITLE
admin_view_schedule_submission

### DIFF
--- a/zlp-scheduler/features/admin_view_schedule_submission.feature
+++ b/zlp-scheduler/features/admin_view_schedule_submission.feature
@@ -1,0 +1,30 @@
+Feature: As an administrator, I want to see which students have submitted their schedules.
+  
+Background: Create Term and Cohort
+ Given The "New Test Term" terms exist 
+ And Registered student and Create term and courses
+ And I am logged in as an admin
+ And I click "New Term"
+ And I fill in the new term form
+ And I should see the admin terms page
+ And I should see "New Test Term"
+ And I should see "Apple"
+ And I click "Open"
+ And I fill in the open term form
+ And I should see the admin terms page
+ And I should see "Term open dates updated."
+ Then I click "Log out"
+
+@javascript
+Scenario: Admin check schedule submission status
+  Given I am a registered student
+  And I am logged in
+  And I click add schedule button
+  And I fill in my courses
+  And I click save schedule button 
+  And I should see added schedule 
+  And I click "Log out"
+  And I am logged in as an admin
+  And I click "Apple"
+  # 1 user submit and 1 user dont submit
+  Then I should see Yes and No

--- a/zlp-scheduler/features/step_definitions/submit_schedule_steps.rb
+++ b/zlp-scheduler/features/step_definitions/submit_schedule_steps.rb
@@ -1,10 +1,19 @@
+Given /The "(.*)" terms exist/ do |term|
+    
+    #@term = Term.create(term)
+    @term = Term.create(:name=>term)
+    @term.opendate = Date.current.yesterday
+    @term.closedate = Date.current.tomorrow
+    @term.active = true
+end
 
 Given(/^Registered student and Create term and courses$/) do
  
   Capybara.server = :webrick
+  
   @testing_department = ["ABC","DEF","GHI","JKL","MNO","PQR","STU"]
  
-  @cohort = FactoryBot.create(:cohort, :name=>"Test Cohort", :term_id=>@term.id)
+  @cohort = FactoryBot.create(:cohort, :name=>"Apple", :term_id=>@term.id)
   @cohort.save()
 
   @user = FactoryBot.create(:user, :role=>"student", :cohort_id=>@cohort.id)
@@ -20,7 +29,7 @@ Given(/^Registered student and Create term and courses$/) do
     end
     @subject.save()
   end
-  
+ 
   @fake_schedule_name = []
   
 end
@@ -160,4 +169,12 @@ Then ("I should see added course information") do
   
   expect(page).to have_xpath(".//tr", count: @record.length + 1)
   #print(page.all("#studentScheduleTable tr").count)
+end
+
+Then ("I should see Yes and No") do
+  
+  expect(page).to have_xpath(".//tr", count: 3)
+  expect(page.body.match?("Yes")).to eq true
+  expect(page.body.match?("No")).to eq true
+  
 end


### PR DESCRIPTION
User story: As an administrator so that I can know when to run the algorithm I want to see which students have submitted their schedules.

I create a new term and a new cohort, then activate them.
After that I add 2 student into cohort, and one of them do the course submission.

So from admin point, she will see 1 student submission status "Yes" and the other is "No".
