### PR TITLE
Fix login bugs and create tests

### DIFF
--- a/zlp-scheduler/app/assets/stylesheets/application.css
+++ b/zlp-scheduler/app/assets/stylesheets/application.css
@@ -187,6 +187,18 @@ label, input[type ='text'] {
     margin-bottom: 20px;
 }
 
+/* Disable arrows in number field of UIN */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    /* display: none; <- Crashes Chrome on hover */
+    -webkit-appearance: none;
+    margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+}
+
+input[type=number] {
+    -moz-appearance:textfield; /* Firefox */
+}
+
 [id^="dept_select"], [id^="course_num_select"], [id^="section_num_select"] {
     min-width: 50px;
 }
@@ -246,11 +258,26 @@ label, input[type ='text'] {
 	margin-top:50px;	
 	width:500px;
 	background-color: rgba(255,255,255, 1);
-	padding-bottom:20px;
+	padding-bottom:60px;
 	padding-top:2px;
-	padding-left: 6px;
+	padding-left: 15px;
 	border-radius: 18px;
-	box-shadow: 5px 5px 5px #888888;
+    box-shadow: 5px 5px 5px #888888;
+}
+
+.Register_Form ul {
+    text-align: left;
+}
+
+.Register_Form .form_label {
+    display: block;
+    margin: 10px auto;
+}
+
+.Register_Form .form_input {
+    display: block;
+    margin: auto;
+    margin-bottom: 15px;
 }
 
 .Input_Large{

--- a/zlp-scheduler/app/assets/stylesheets/scaffolds.scss
+++ b/zlp-scheduler/app/assets/stylesheets/scaffolds.scss
@@ -56,11 +56,10 @@ div {
 .field_with_errors {
   padding: 2px;
   background-color: red;
-  display: table;
 }
 
 #error_explanation {
-  width: 450px;
+  width: 95%;
   border: 2px solid red;
   padding: 7px;
   padding-bottom: 0;

--- a/zlp-scheduler/app/controllers/sessions_controller.rb
+++ b/zlp-scheduler/app/controllers/sessions_controller.rb
@@ -12,26 +12,29 @@ class SessionsController < ApplicationController
       else
         @user = User.find_by_email(params[:session][:email].downcase)
         if @user.nil? || (@user && !@user.authenticate(params[:session][:password]))
-          flash[:login_errors]= ['Email or password is invalid']
+          flash[:login_errors] = ['Email or password is invalid']
           redirect_to '/'
           return
         end
-        flash[:notice] = 'Logged in!'
       end
+      if @user.activate == false
+        flash[:login_errors] = ['You should claim your account first']
+        redirect_to '/'
+        return
+      end
+      flash[:notice] = 'Logged in!'
       session[:user_id] = @user.id
       @term = Term.find_by active: 1
-      if @term.nil?
-        Term.ImportTermList!
-      end
+      Term.ImportTermList! if @term.nil?
       if current_user.admin?
         redirect_to view_term_admin_path
       else
-        redirect_to '/student/view_terms' 
+        redirect_to '/student/view_terms'
       end
-    end 
-    
+    end
+
     def destroy 
-      session[:user_id] = nil 
+      session[:user_id] = nil
       redirect_to '/login', :notice => "Logged out!" 
     end
 end

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -114,20 +114,17 @@ class UsersController < ApplicationController
       @user.errors.add(:email, 'is already claimed before')
       render 'new'
     else
-      @user.update_attributes(password: params[:user][:password],
-                              password_confirmation: params[:user][:password_confirmation],
-                              activate: true)
+      @user.update_attributes(password: params[:user][:password], activate: true,
+                              password_confirmation: params[:user][:password_confirmation])
       if @user.save
         session[:user_id] = @user.id
         @term = Term.find_by active: 1
         term.ImportTermList! if @term.nil?
         if current_user.admin?
-          redirect_to view_term_admin_path, :notice => "Logged in!" 
+          redirect_to view_term_admin_path, notice: 'You have claimed your account'
         else
-          redirect_to '/student/view_terms', :notice => "Logged in!"
+          redirect_to '/student/view_terms', notice: 'You have claimed your account'
         end
-        Term.ImportTermList! if @term.nil?
-        flash[:notice] = 'You have claimed your account'
       else
         render 'new'
       end

--- a/zlp-scheduler/app/controllers/users_controller.rb
+++ b/zlp-scheduler/app/controllers/users_controller.rb
@@ -64,7 +64,7 @@ class UsersController < ApplicationController
         @user.email = spreadsheet.row(i)[3]
         @user.role = 'student'
         @user.password = "Temp"
-        @user.actiave = false
+        @user.activate = false
         @user.save
         @cohort.users.push(@user)
       end

--- a/zlp-scheduler/app/models/user.rb
+++ b/zlp-scheduler/app/models/user.rb
@@ -1,36 +1,45 @@
 class User < ApplicationRecord
   has_secure_password
-  validates :email, uniqueness: true
   has_many :schedules, dependent: :destroy
   has_one :cohort
-  
-  #takes care of caps/spaces inconsistency in email during registration
-    def email=(value)
-        value = value.strip.downcase
-        write_attribute :email, value
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  validates :email, presence: true,
+                    format: { with: VALID_EMAIL_REGEX },
+                    uniqueness: true
+
+  validates :password, presence: true,
+                       length: { within: 4..20 },
+                       confirmation: true,
+                       if: :password_digest_changed?
+
+  def email=(value)
+    value = value.strip.downcase
+    write_attribute :email, value
+  end
+
+  # role-based authorization
+  def student?
+    role == 'student'
+  end
+
+  def admin?
+    role == 'admin'
+  end
+
+  # password_reset email, should expire after sometime.
+  def send_password_reset
+    generate_token(:password_reset_token)
+    update_attributes!(password_reset_sent_at: Time.zone.now)
+    UserMailer.password_reset(self).deliver
+  end
+
+  private
+
+  # accepts a column name and uses secure random to genearate a random string as token and makes sure token is unique.
+  def generate_token(column)
+    loop do
+      self[column] = SecureRandom.urlsafe_base64
+      break unless User.exists?(column => self[column])
     end
-    
-    #role-based authorization
-    def student? 
-  		self.role == 'student' 
-    end
-    def admin? 
-  		self.role == 'admin' 
-    end
-    
-    #password_reset email, should expire after sometime.
-    def send_password_reset
-      generate_token(:password_reset_token)
-      self.password_reset_sent_at = Time.zone.now
-      save!
-      UserMailer.password_reset(self).deliver
-    end
-    
-    #accepts a column name and uses secure random to genearate a random string as token and makes sure token is unique.
-    def generate_token(column)
-      begin
-        self[column] = SecureRandom.urlsafe_base64
-      end while User.exists?(column => self[column])
-    end
-    
+  end
 end

--- a/zlp-scheduler/app/models/user.rb
+++ b/zlp-scheduler/app/models/user.rb
@@ -2,11 +2,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :schedules, dependent: :destroy
   has_one :cohort
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   validates :email, presence: true,
-                    format: { with: VALID_EMAIL_REGEX },
                     uniqueness: true
-
   validates :password, presence: true,
                        length: { within: 4..20 },
                        confirmation: true,

--- a/zlp-scheduler/app/views/admin/add_admin.html.haml
+++ b/zlp-scheduler/app/views/admin/add_admin.html.haml
@@ -13,7 +13,7 @@
                 %td#specialTableData
                     = f.text_field :lastname
                 %td#specialTableData
-                    = f.email_field :email
+                    = f.email_field :email, :placeholder => "netid@tamu.edu", :pattern => ".+@tamu.edu", :title => "Only tamu email id", :size => 30, :required => true
                 %td#specialTableData
                     = f.number_field :uin
         %br

--- a/zlp-scheduler/app/views/admin/add_admin.html.haml
+++ b/zlp-scheduler/app/views/admin/add_admin.html.haml
@@ -13,9 +13,9 @@
                 %td#specialTableData
                     = f.text_field :lastname
                 %td#specialTableData
-                    = f.text_field :email
+                    = f.email_field :email
                 %td#specialTableData
-                    = f.text_field :uin
+                    = f.number_field :uin
         %br
         = f.submit "Create", :class => 'button_link'
         = link_to "Cancel", manage_administrators_path, :class => 'button_link'

--- a/zlp-scheduler/app/views/password_resets/new.html.erb
+++ b/zlp-scheduler/app/views/password_resets/new.html.erb
@@ -2,7 +2,7 @@
     <%= form_tag password_resets_path, :method => :post do %>
         <h2 style="color:black;">Password Reset</h2>
         <%= label_tag "Email: "%>
-        <%= text_field_tag :email, params[:email], :pattern => ".+@tamu.edu", :title => "Only tamu email id", :size => 30, :class=> "Input_Medium"  %>
+        <%= email_field_tag :email, params[:email], :pattern => ".+@tamu.edu", :title => "Only tamu email id", :size => 30, :class=> "Input_Medium"  %>
         <%= submit_tag "Reset Password", class: "btn-submit" %>
          <% end %>
         <p class="alignleft"> <%=link_to "New User?", '/signup' %></p>

--- a/zlp-scheduler/app/views/users/new.html.erb
+++ b/zlp-scheduler/app/views/users/new.html.erb
@@ -1,38 +1,35 @@
-<div class= "topright" style="color: #ffffff;">
-<p>Already have an account? <%=  link_to "Sign in", '/login', style: 'color:white;' %></p>
-</div>
+<div class= "topright" style="color: #ffffff;"></div>
 
 <div class= "Register_Form">
-    <h1 style="color:black;">Claim Account </h1>
-    <%= form_for @user, method: :patch do |f| %>  
-     <div class="field"> 
-      Are you a student? 
-      <%= f.radio_button :role, 'student', :required => true %>
-      <%= f.label :role_student, 'Yes' %>
-      <%= f.radio_button :role, 'admin', :required => true %>
-      <%= f.label :role_admin, 'No' %>
-       </div>
-      <br>
-      
-      UIN<br> <%= f.number_field :uin, :size => 10, :class => "Input_Medium", :required => true %><br />
-      <br>First name<br> <%= f.text_field :firstname, :size => 20, :class => "Input_Medium", :required => true %><br />
-      <br>Last name<br> <%= f.text_field :lastname, :size => 20, :class => "Input_Medium", :required => true %><br />
-      <br>Email<br> <%= f.text_field :email, :placeholder => "netid@tamu.edu", :pattern => ".+@tamu.edu", :title => "Only tamu email id", :size => 30, :class => "Input_Medium", :required => true %><br />
-      <br>Password<br> <%= f.password_field :password, :size => 30, :class => "Input_Medium", :required => true %><br />
-      <br>Retype Password<br> <%= f.password_field :password_confirmation, :size => 30, :class => "Input_Medium", :required => true %><br />
-   
-   <br>
+    <h2 style="color:black;">Claim Account </h1>
+    <% if !@user.nil? and @user.errors.any? %>
+      <div id="error_explanation">
+        <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_with(model: @user, method: :patch, url: users_path(@user)) do |f| %>      
+      <%= f.label(:uin, 'UIN', :class => 'form_label' )%>
+      <%= f.number_field :uin, :size => 10, :class => "Input_Medium, 'form_input'", :required => true%>
+      <%= f.label(:email, 'Email', :class => 'form_label') %>
+      <%= f.email_field :email, :placeholder => "netid@tamu.edu", :pattern => ".+@tamu.edu", :title => "Only tamu email id", :size => 30, :class => "Input_Medium, 'form_input'", :required => true%>
+      <%= f.label(:password_field, 'Password', :class => 'form_label') %>
+      <%= f.password_field :password, :size => 30, :class => "Input_Medium, form_input", :required => true %>
+      <%= f.label(:password_confirmation, 'Retype Password', :class => 'form_label') %>
+      <%= f.password_field :password_confirmation, :size => 30, :class => "Input_Medium, form_input", :required => true%>
+  
   <div class="actions"> 
     <%= f.submit "Sign up", class: "btn-submit" %> 
   </div> 
+
 <% end %> 
 
-  <div class= "errors">
-        <% if flash[:register_errors]%>
-            <% flash[:register_errors].each do |error| %>
-                <p> <%= error%> </p>
-            <%end%>
-        <%end%>
-    </div>
+  <p class="alignleft"> <%=link_to "Existing User?", '/login' %></p>
+  <p class="alignright"> <%=link_to "Forgot Password?", new_password_reset_path %></p>
+
 </div>
   

--- a/zlp-scheduler/db/migrate/20201123044850_add_activate_to_user.rb
+++ b/zlp-scheduler/db/migrate/20201123044850_add_activate_to_user.rb
@@ -1,0 +1,5 @@
+class AddActivateToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activate, :boolean, default: true
+  end
+end

--- a/zlp-scheduler/db/schema.rb
+++ b/zlp-scheduler/db/schema.rb
@@ -10,19 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201103011810) do
+ActiveRecord::Schema.define(version: 2020_11_23_044850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "cohorts", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.integer  "term_id"
-    t.integer  "time_slots_id"
-    t.integer  "chosen_time"
-    t.index ["time_slots_id"], name: "index_cohorts_on_time_slots_id", using: :btree
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "term_id"
+    t.integer "time_slots_id"
+    t.integer "chosen_time"
+    t.index ["time_slots_id"], name: "index_cohorts_on_time_slots_id"
   end
 
   create_table "conflicts", force: :cascade do |t|
@@ -31,96 +31,97 @@ ActiveRecord::Schema.define(version: 20201103011810) do
     t.integer "course_id"
     t.integer "schedule_id"
     t.integer "time_slot_id"
-    t.index ["course_id"], name: "index_conflicts_on_course_id", using: :btree
-    t.index ["schedule_id"], name: "index_conflicts_on_schedule_id", using: :btree
-    t.index ["time_slot_id"], name: "index_conflicts_on_time_slot_id", using: :btree
-    t.index ["user_id"], name: "index_conflicts_on_user_id", using: :btree
+    t.index ["course_id"], name: "index_conflicts_on_course_id"
+    t.index ["schedule_id"], name: "index_conflicts_on_schedule_id"
+    t.index ["time_slot_id"], name: "index_conflicts_on_time_slot_id"
+    t.index ["user_id"], name: "index_conflicts_on_user_id"
   end
 
   create_table "courses", force: :cascade do |t|
-    t.string   "full_subject"
-    t.string   "abbreviated_subject"
-    t.string   "course_name"
-    t.integer  "course_number"
-    t.integer  "section_number"
+    t.string "full_subject"
+    t.string "abbreviated_subject"
+    t.string "course_name"
+    t.integer "course_number"
+    t.integer "section_number"
     t.datetime "meetingtime_start"
     t.datetime "meetingtime_end"
-    t.string   "meeting_days",                     array: true
-    t.string   "instructors",                      array: true
-    t.string   "meeting_location"
-    t.integer  "term_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.integer  "subject_id"
+    t.string "meeting_days", array: true
+    t.string "instructors", array: true
+    t.string "meeting_location"
+    t.integer "term_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "subject_id"
     t.index ["instructors"], name: "index_courses_on_instructors", using: :gin
     t.index ["meeting_days"], name: "index_courses_on_meeting_days", using: :gin
-    t.index ["subject_id"], name: "index_courses_on_subject_id", using: :btree
-    t.index ["term_id"], name: "index_courses_on_term_id", using: :btree
+    t.index ["subject_id"], name: "index_courses_on_subject_id"
+    t.index ["term_id"], name: "index_courses_on_term_id"
   end
 
   create_table "schedule_to_courses", force: :cascade do |t|
-    t.integer  "schedule_id"
-    t.integer  "course_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.boolean  "mandatory",   default: false
-    t.index ["course_id"], name: "index_schedule_to_courses_on_course_id", using: :btree
-    t.index ["schedule_id"], name: "index_schedule_to_courses_on_schedule_id", using: :btree
+    t.integer "schedule_id"
+    t.integer "course_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "mandatory", default: false
+    t.index ["course_id"], name: "index_schedule_to_courses_on_course_id"
+    t.index ["schedule_id"], name: "index_schedule_to_courses_on_schedule_id"
   end
 
   create_table "schedules", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "user_id"
+    t.string "name"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_schedules_on_user_id", using: :btree
+    t.index ["user_id"], name: "index_schedules_on_user_id"
   end
 
   create_table "subjects", force: :cascade do |t|
-    t.string   "subject_code"
-    t.string   "subject_description"
-    t.integer  "term_id"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
-    t.index ["term_id"], name: "index_subjects_on_term_id", using: :btree
+    t.string "subject_code"
+    t.string "subject_description"
+    t.integer "term_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["term_id"], name: "index_subjects_on_term_id"
   end
 
   create_table "terms", force: :cascade do |t|
-    t.string   "name"
+    t.string "name"
     t.datetime "opendate"
     t.datetime "closedate"
-    t.datetime "created_at",                              null: false
-    t.datetime "updated_at",                              null: false
-    t.string   "term_code"
-    t.boolean  "active",                  default: false
-    t.boolean  "courses_import_complete", default: false
-    t.index ["term_code"], name: "index_terms_on_term_code", unique: true, using: :btree
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "term_code"
+    t.boolean "active", default: false
+    t.boolean "courses_import_complete", default: false
+    t.index ["term_code"], name: "index_terms_on_term_code", unique: true
   end
 
   create_table "time_slots", force: :cascade do |t|
     t.datetime "time"
-    t.integer  "cost"
-    t.boolean  "was_conflict"
-    t.integer  "cohort_id"
-    t.string   "day"
-    t.integer  "conflicts_id"
-    t.index ["cohort_id"], name: "index_time_slots_on_cohort_id", using: :btree
-    t.index ["conflicts_id"], name: "index_time_slots_on_conflicts_id", using: :btree
+    t.integer "cost"
+    t.boolean "was_conflict"
+    t.integer "cohort_id"
+    t.string "day"
+    t.integer "conflicts_id"
+    t.index ["cohort_id"], name: "index_time_slots_on_cohort_id"
+    t.index ["conflicts_id"], name: "index_time_slots_on_conflicts_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer  "uin"
-    t.string   "lastname",               null: false
-    t.string   "firstname",              null: false
-    t.string   "email",                  null: false
-    t.string   "password_digest"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.string   "role"
-    t.string   "password_reset_token"
+    t.integer "uin"
+    t.string "lastname", null: false
+    t.string "firstname", null: false
+    t.string "email", null: false
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "role"
+    t.string "password_reset_token"
     t.datetime "password_reset_sent_at"
     t.datetime "password_expires_after"
-    t.integer  "cohort_id"
+    t.integer "cohort_id"
+    t.boolean "activate", default: true
   end
 
   add_foreign_key "courses", "subjects"

--- a/zlp-scheduler/features/authentication.feature
+++ b/zlp-scheduler/features/authentication.feature
@@ -90,9 +90,28 @@ Scenario: A Student Reset Password expired
   And I wait 2 hours
   When I confirm the reset
   Then I should see the password reset has expired
-# Scenario: A Registered User Can Claim His Account
-# Scenario: A Registered User Cannot Claim His Account when UIN and Email not match
-# Scenario: A Unregistered User Cannot Claim His Account
-# Scenario: A Registered User Cannot Claim His account with a Weak Password
-# Scenario: An Unclaimed Account Cannot Login
-# Scenario: An Unclaimed Account Cannot Reset Password
+
+Scenario Outline: Claim Acoout - possible combinations
+  Given the following user exist:
+  | uin       | email                  | password | retype | activate |
+  | 000000001 | new_account@tamu.edu   | aaaa     | aaaa   | false    |
+  | 000000005 | old_account@tamu.edu   | aaaa     | aaaa   | true     |
+
+  And I visit the index page
+  And I click "New User?"
+  And I enters "<uin>" in "uin" field
+  And I enters "<email>" in "email" field
+  And I enters "<password>" in "password" field
+  And I enters "<retype>" in "password_confirmation" field
+  And I click button "Sign up"
+  Then I should see information "<information>"
+
+  Examples: 
+  | uin       | email                  | password | retype | information                                  |
+  | 000000001 |  new_account@tamu.edu  | aaaa     | aaaa   | You have claimed your account                |
+  | 000000002 |  new_account@tamu.edu  | aaaa     | aaaa   | Email not registered or UIN not matched      |
+  | 000000001 |  wrongaccount@tamu.edu | aaaa     | aaaa   | Email not registered or UIN not matched      |
+  | 000000002 |  wrongaccount@tamu.edu | aaaa     | aaaa   | Email not registered or UIN not matched      |
+  | 000000001 |  new_account@tamu.edu  | aa       | aa     | Password is too short                        |
+  | 000000001 |  new_account@tamu.edu  | aaaa     | bbbb   | Password confirmation doesn't match Password |
+  | 000000005 |  old_account@tamu.edu  | aaaa     | aaaa   | Email is already claimed before              |

--- a/zlp-scheduler/features/crud_admin.feature
+++ b/zlp-scheduler/features/crud_admin.feature
@@ -43,6 +43,15 @@ Scenario: Added administrator can claim account
   And I fill out the new user form
   Then I should see the admin terms page
   And I should see "Howdy, John!"
+
+Scenario: Added administrator can not login without claim account
+  When I click "Manage Administrators"
+  And I click "Add Administrator"
+  And I fill in the add admin form
+  And I click on the log out link
+  And I login with the new user account
+  Then I should not be logged in
+  And I should see information "You should claim your account first"
   
 Scenario: Edit Administrator Cancel Button
   When I click "Manage Administrators"

--- a/zlp-scheduler/features/step_definitions/admin_steps.rb
+++ b/zlp-scheduler/features/step_definitions/admin_steps.rb
@@ -6,15 +6,19 @@ When /^I fill in the add admin form$/ do
     click_button("Create")
 end
 
-When /^I fill out the new user form/ do
-    choose("user_role_admin")
-    fill_in "user_uin", with: "1000"
-    fill_in "user_firstname", with: "John"
-    fill_in "user_lastname", with: "Doe"
-    fill_in "user_email", with: "blah@tamu.edu"
-    fill_in "user_password", with: "1234"
-    fill_in "user_password_confirmation", with: "1234"
-    click_button("Sign up")
+When(/^I fill out the new user form/) do
+    fill_in 'user[uin]', with: '1000'
+    fill_in 'user[email]', with: 'blah@tamu.edu'
+    fill_in 'user[password]', with: '1234'
+    fill_in 'user[password_confirmation]', with: '1234'
+    click_button('Sign up')
+end
+
+When(/^I login with the new user account/) do
+    fill_in 'Email', with: 'blah@tamu.edu'
+    # The default is Temp
+    fill_in 'Password', with: 'Temp'
+    click_button('Log in')
 end
 
 When /^I edit the administrator/ do

--- a/zlp-scheduler/features/step_definitions/admin_steps.rb
+++ b/zlp-scheduler/features/step_definitions/admin_steps.rb
@@ -7,10 +7,10 @@ When /^I fill in the add admin form$/ do
 end
 
 When(/^I fill out the new user form/) do
-    fill_in 'user[uin]', with: '1000'
-    fill_in 'user[email]', with: 'blah@tamu.edu'
-    fill_in 'user[password]', with: '1234'
-    fill_in 'user[password_confirmation]', with: '1234'
+    find("input[name='user[uin]']").set('1000')
+    find("input[name='user[email]']").set('blah@tamu.edu')
+    find("input[name='user[password]']").set('1234')
+    find("input[name='user[password_confirmation]']").set('1234')
     click_button('Sign up')
 end
 

--- a/zlp-scheduler/features/step_definitions/authentication_steps.rb
+++ b/zlp-scheduler/features/step_definitions/authentication_steps.rb
@@ -18,7 +18,7 @@ Then (/^I should (not )?be logged in$/) do |is_not|
   if is_not == nil
     expect(page).to have_content("Logged in!")
   else
-    expect(page).to have_content("Email or password is invalid")
+    page.should have_content(/Email or password is invalid|You should claim your account/)
     expect(current_path).to eq "/"
   end
 end
@@ -58,10 +58,6 @@ Then(/^the current term is (not )?open$/) do |is_not|
   end
 end
 
-When('I click on the signup link') do
-  click_link('New User?')
-end
-
 When('I click on the forgot password link') do
   click_link('Forgot Password?')
 end
@@ -70,7 +66,8 @@ When('I fill in the sign up form') do
   fill_in "user[uin]", :with => @user.uin
   fill_in "user[email]", :with => @user.email
   fill_in "user[password_confirmation]", :with => @user.password
-  click_button("Sign up")end
+  click_button("Sign up")
+end
 
 And('I fill in the password reset form') do
   fill_in "email", :with => @user.email
@@ -97,6 +94,26 @@ end
 
 Then('I should see the password reset has expired') do
   expect(page).to have_content("Password reset has expired")
+end
+
+Given('the following user exist:') do |user_table|
+  user_table.hashes.each do |u|
+    @user = FactoryBot.create(:user, uin: u['uin'], email: u['email'],
+                                     role: 'student', cohort_id: @cohort.id,
+                                     activate: u['activate'] == 'true')
+  end
+end
+
+When('I enters {string} in {string} field') do |string, string2|
+  fill_in(format('user[%s]', string2), with: string)
+end
+
+Then /I should (not )?see information "(.*)"/ do |is_not, string|
+  if is_not
+    expect(page).to have_no_content(string)
+  else
+    expect(page).to have_content(string)
+  end
 end
 
 Given /I am (not )?in the active cohort$/ do |is_not|


### PR DESCRIPTION
Bug fix:

- A user can login with temp password before claiming his account
- A user can claim his account multiple times
- A user can claim his account even if he does not retype the password correctly
- A user does not see any error message even if the submitted form has error and his record is not updated

Other changes:

- Remove `firstname`, `lastname`, and `usertype` in the signup form because it is meaningless for users to change them
- Refine the UI of signup form, let it display more detail error messages if the submitted form is incorrect
- Add corresponding tests