### PR TITLE
Setup email

### DIFF
--- a/zlp-scheduler/app/controllers/password_resets_controller.rb
+++ b/zlp-scheduler/app/controllers/password_resets_controller.rb
@@ -7,8 +7,13 @@ class PasswordResetsController < ApplicationController
   def create
     @user = User.find_by_email(params[:email])
     if @user
-      @user.send_password_reset
-      redirect_to '/', notice: 'Email sent with password reset instructions'
+      if @user.activate == false
+        flash[:login_errors] = ['You should claim your account first']
+        redirect_to '/'
+      else
+        @user.send_password_reset
+        redirect_to '/', notice: 'Email sent with password reset instructions'
+      end
     else
       flash[:warning] = 'Email is not registered'
       render :new

--- a/zlp-scheduler/app/mailers/application_mailer.rb
+++ b/zlp-scheduler/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
   # ToDo: setup the sender email and send verification email on send grid
-  default from: '@tamu.edu'
+  default from: ENV['SENDGRID_SENDER']
   layout 'mailer'
 end

--- a/zlp-scheduler/app/views/password_resets/edit.html.erb
+++ b/zlp-scheduler/app/views/password_resets/edit.html.erb
@@ -1,18 +1,16 @@
-
-
-<%= form_for @user, :url => password_reset_path(params[:id]) do |f| %>
-  <% if @user.errors.any? %>
-    <div class="error_messages">
-      <h2>Form is invalid</h2>
-      <ul>
-        <% for message in @user.errors.full_messages %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-  <div class="Sign_Form">
-     <h2 style="color:black;">Reset Password</h2>
+  <div class="Register_Form">
+    <%= form_for @user, :url => password_reset_path(params[:id]) do |f| %>
+    <% if @user.errors.any? %>
+      <div class="error_messages">
+        <h2>Form is invalid</h2>
+        <ul>
+          <% for message in @user.errors.full_messages %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <h2 style="color:black;">Reset Password</h2>
     <%= f.label :password %>
     <br>
     <%= f.password_field :password, :size => 30, :class=> "Input_Medium" %>

--- a/zlp-scheduler/app/views/users/new.html.erb
+++ b/zlp-scheduler/app/views/users/new.html.erb
@@ -21,12 +21,11 @@
       <%= f.password_field :password, :size => 30, :class => "Input_Medium, form_input", :required => true %>
       <%= f.label(:password_confirmation, 'Retype Password', :class => 'form_label') %>
       <%= f.password_field :password_confirmation, :size => 30, :class => "Input_Medium, form_input", :required => true%>
-  
-  <div class="actions"> 
-    <%= f.submit "Sign up", class: "btn-submit" %> 
-  </div> 
 
-<% end %> 
+      <div class="actions"> 
+        <%= f.submit "Sign up", class: "btn-submit" %> 
+      </div> 
+    <% end %> 
 
   <p class="alignleft"> <%=link_to "Existing User?", '/login' %></p>
   <p class="alignright"> <%=link_to "Forgot Password?", new_password_reset_path %></p>

--- a/zlp-scheduler/config/environments/production.rb
+++ b/zlp-scheduler/config/environments/production.rb
@@ -93,5 +93,5 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
 
   # host needs to be chnaged when on heroku put the heroku url
-  config.action_mailer.default_url_options = { host: ENV['HEROKU_URL:'] }
+  config.action_mailer.default_url_options = { host: ENV['HEROKU_URL'] }
 end

--- a/zlp-scheduler/config/environments/production.rb
+++ b/zlp-scheduler/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   config.action_mailer.default :charset => "utf-8"
   #send emails in production?
   config.action_mailer.perform_deliveries = true
-  
-  #host needs to be chnaged when on heroku put the heroku url
-  config.action_mailer.default_url_options = {:host => "https://e6e50639ce9142959ad27a142c414481.vfs.cloud9.us-east-2.amazonaws.com/"}
+
+  # host needs to be chnaged when on heroku put the heroku url
+  config.action_mailer.default_url_options = { host: ENV['HEROKU_URL:'] }
 end

--- a/zlp-scheduler/features/crud_admin.feature
+++ b/zlp-scheduler/features/crud_admin.feature
@@ -63,7 +63,16 @@ Scenario: Added administrator can not login without claim account
   And I login with the new user account
   Then I should not be logged in
   And I should see information "You should claim your account first"
-  
+
+Scenario: Added administrator can not reset password without claim account
+  When I click "Manage Administrators"
+  And I click "Add Administrator"
+  And I fill in the add admin form
+  And I click on the log out link
+  When I click on the forgot password link
+  And I fill in the new user email
+  And I should see information "You should claim your account first"
+
 Scenario: Edit Administrator Cancel Button
   When I click "Manage Administrators"
   And I click "Edit"

--- a/zlp-scheduler/features/step_definitions/admin_steps.rb
+++ b/zlp-scheduler/features/step_definitions/admin_steps.rb
@@ -21,6 +21,11 @@ When(/^I login with the new user account/) do
     click_button('Log in')
 end
 
+And('I fill in the new user email') do
+    fill_in 'email', with: 'blah@tamu.edu'
+    click_button('Reset Password')
+end
+
 When /^I edit the administrator/ do
     fill_in "user_lastname", with: "Smith"
     click_button("Update")


### PR DESCRIPTION
Changes
- Modify the code to read sender, app url, and send grid api key from config (instead of hard code the setting)
- Fix some defects
  - The error message displayed in the email reset form was not clear
  - We should not allow a user to reset his password if he have not claimed his account yet

Note, we also need to set the config from heroku command line
- heroku config:set SENDGRID_API_KEY `Your-Api-Key`
- heroku config:set SENDGRID_SENDER `xxx@tamu.edu`