### PR TITLE
fix run algorithm twice bug

### DIFF
--- a/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
+++ b/zlp-scheduler/app/controllers/concerns/scheduler_2.rb
@@ -47,6 +47,7 @@ class Scheduler_2
     def self.Generate_time_slots(cohort)
         
         TimeSlot.where(:cohort_id => cohort.id).destroy_all
+        cohort.chosen_time = nil
         conflict_mods = Array.new
         time_preferences = Array.new
         time_slots = Array.new

--- a/zlp-scheduler/features/view_result_testing.feature
+++ b/zlp-scheduler/features/view_result_testing.feature
@@ -26,7 +26,18 @@ Scenario: View the view result and non-conflict result
   And I go to view cohort page for Test Cohort
   Then I should see the view cohort page for Test Cohort 
   Then I should see time slot selected for Test Cohort 
-  
+
+Scenario: Run Algorithm Twice
+  When I click "Test Cohort"
+  When I click "Run Algorithm"
+  When I click "Find Class Time"
+  When I click button "Choose"
+  And I go to view cohort page for Test Cohort
+  Then I should see the view cohort page for Test Cohort
+  Then I should see time slot selected for Test Cohort
+  When I click "Run Algorithm"
+  Then I should see the view cohort page for Test Cohort
+
 Scenario: View the view result and non-conflict result
   When I click "Test Cohort"
   And I click "Run Algorithm"


### PR DESCRIPTION
Because the `TimeSlot` will be destroyed when we rerun the algorithm,  `cohort.chosen_time` also need to  reset to `nil`. 
Otherwise, `admin_controller` cannot find the previous selected `TimeSlot`.